### PR TITLE
ensure that no polyfills are required

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,0 +1,45 @@
+let requiredPolyfills = new Set();
+
+let checkPolyfillsTimeout;
+
+function checkRequiredPolyfills() {
+  if (requiredPolyfills.size === 0) return;
+
+  console.error(
+    '\nThe following polyfills are required:\n\t' +
+      Array.from(requiredPolyfills).sort().join('\n\t') +
+      '\n',
+  );
+
+  process.exitCode = 1;
+}
+
+const plugins = [];
+
+if (process.env.CHECK_POLYFILLS === 'true') {
+  plugins.push([
+    'polyfill-corejs3',
+    {
+      method: 'usage-pure',
+      shouldInjectPolyfill(name, defaultShouldInject) {
+        if (defaultShouldInject) {
+          requiredPolyfills.add(name);
+        }
+
+        clearTimeout(checkPolyfillsTimeout);
+
+        checkPolyfillsTimeout = setTimeout(() => {
+          checkRequiredPolyfills();
+          requiredPolyfills = new Set();
+        }, 1000);
+
+        return false;
+      },
+      proposals: true,
+    },
+  ]);
+}
+
+module.exports = {
+  plugins,
+};

--- a/README.md
+++ b/README.md
@@ -107,33 +107,33 @@ The following [browserslist](https://github.com/browserslist/browserslist) is su
 <details>
   <summary>>0.25% or last 2 major versions and supports es6-module</summary>
 
-  <p style="white-space: pre">
-  <strong>caniuse-lite db date: 15/02/2020</strong>
-  and_chr 87
-  and_ff 83
-  and_qq 10.4
-  android 81
-  chrome 87
-  chrome 86
-  chrome 85
-  edge 87
-  edge 86
-  firefox 84
-  firefox 83
-  ios_saf 14.0-14.3
-  ios_saf 13.4-13.7
-  ios_saf 13.3
-  ios_saf 13.2
-  ios_saf 13.0-13.1
-  ios_saf 12.2-12.4
-  opera 72
-  opera 71
-  safari 14
-  safari 13.1
-  safari 13
-  samsung 13.0
-  samsung 12.0
-  </p>
+  <p><strong>caniuse-lite db date: 15/02/2020</strong></p>
+  <ul>
+    <li>and_chr 87</li>
+    <li>and_ff 83</li>
+    <li>and_qq 10.4</li>
+    <li>android 81</li>
+    <li>chrome 87</li>
+    <li>chrome 86</li>
+    <li>chrome 85</li>
+    <li>edge 87</li>
+    <li>edge 86</li>
+    <li>firefox 84</li>
+    <li>firefox 83</li>
+    <li>ios_saf 14.0-14.3</li>
+    <li>ios_saf 13.4-13.7</li>
+    <li>ios_saf 13.3</li>
+    <li>ios_saf 13.2</li>
+    <li>ios_saf 13.0-13.1</li>
+    <li>ios_saf 12.2-12.4</li>
+    <li>opera 72</li>
+    <li>opera 71</li>
+    <li>safari 14</li>
+    <li>safari 13.1</li>
+    <li>safari 13</li>
+    <li>samsung 13.0</li>
+    <li>samsung 12.0</li>
+  </ul>
 </details>
 
 ## Alternatives

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ renders the following line:
 
 The _quick_ _brown_ **fox** jumps over the _lazy_ **dog**. [Wikipedia]("https://en.wikipedia.org/wiki/The_quick_brown_fox_jumps_over_the_lazy_dog")
 
-For more examples, see the [stories](./stories/Marksome.stories.tsx).
+For more examples, see the [stories](./stories/Marksome.stories.tsx) together with related [fixtures](./test/fixtures.ts).
 
 ## API
 
@@ -99,6 +99,42 @@ All of the above means that users don't need to worry about escaping the text si
 
 - it relies on regular React components instead of injecting HTML via [dangerouslySetInnerHTML](https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml)
 - the only way to inject a link is via a separate references object.
+
+## Supported browsers
+
+The following [browserslist](https://github.com/browserslist/browserslist) is supported without the need of any polyfills:
+
+<details>
+  <summary>>0.25% or last 2 major versions and supports es6-module</summary>
+
+  <p style="white-space: pre">
+  <strong>caniuse-lite db date: 15/02/2020</strong>
+  and_chr 87
+  and_ff 83
+  and_qq 10.4
+  android 81
+  chrome 87
+  chrome 86
+  chrome 85
+  edge 87
+  edge 86
+  firefox 84
+  firefox 83
+  ios_saf 14.0-14.3
+  ios_saf 13.4-13.7
+  ios_saf 13.3
+  ios_saf 13.2
+  ios_saf 13.0-13.1
+  ios_saf 12.2-12.4
+  opera 72
+  opera 71
+  safari 14
+  safari 13.1
+  safari 13
+  samsung 13.0
+  samsung 12.0
+  </p>
+</details>
 
 ## Alternatives
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7066,6 +7066,40 @@
       "integrity": "sha512-squySRkf+6JGnvjoUtDEjSREJEBirnXi9NqP6rjSYsylxQxqBTz+pkmf395i9E2zsvmYUaI40BHo6SqZUdydlw==",
       "dev": true
     },
+    "babel-plugin-polyfill-corejs3": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.1.0.tgz",
+      "integrity": "sha512-1xoNvGbuJVXVRLyalANHp4xPMvlIW5+Gme7QHNZNIXCRZ8YUY1muQjaDkJTAgbkxFvtnALGtnk/v6RfrgKTpGg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-define-polyfill-provider": "^0.1.0",
+        "core-js-compat": "^3.8.1"
+      },
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.1.0.tgz",
+          "integrity": "sha512-/nX4CQRve5OZsc0FsvkuefeIQFG7GQo2X5GbD/seME7Tu4s2gHuQfXTIKup++/W9K1SWi2dTe7H9zhgJxhn/pA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-compilation-targets": "^7.10.4",
+            "@babel/helper-module-imports": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/traverse": "^7.11.5",
+            "debug": "^4.1.1",
+            "lodash.debounce": "^4.0.8",
+            "resolve": "^1.14.2",
+            "semver": "^6.1.2"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "babel-plugin-polyfill-regenerator": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.0.4.tgz",
@@ -7947,9 +7981,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001179",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001179.tgz",
-      "integrity": "sha512-blMmO0QQujuUWZKyVrD1msR4WNDAqb/UPO1Sw2WWsQ7deoM5bJiicKnWJ1Y0NS/aGINSnKPIWBMw5luX+NDUCA==",
+      "version": "1.0.30001187",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001187.tgz",
+      "integrity": "sha512-w7/EP1JRZ9552CyrThUnay2RkZ1DXxKe/Q2swTC4+LElLh9RRYrL1Z+27LlakB8kzY0fSmHw9mc7XYDUKAKWMA==",
       "dev": true
     },
     "capture-exit": {
@@ -12546,33 +12580,25 @@
       }
     },
     "internal-slot": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.2.tgz",
-      "integrity": "sha512-2cQNfwhAfJIkU4KZPkDI+Gj5yNNnbqi40W9Gge6dfnk4TocEVm00B3bdiL+JINrbGJil2TeHvM4rETGzk/f/0g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
       "dev": true,
       "requires": {
-        "es-abstract": "^1.17.0-next.1",
+        "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
-        "side-channel": "^1.0.2"
+        "side-channel": "^1.0.4"
       },
       "dependencies": {
-        "es-abstract": {
-          "version": "1.17.7",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
-          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
           "dev": true,
           "requires": {
-            "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
+            "has-symbols": "^1.0.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   },
   "scripts": {
     "start": "tsdx watch",
-    "build": "tsdx build",
+    "build": "CHECK_POLYFILLS=true tsdx build",
     "test": "tsdx test",
     "lint": "tsdx lint src test stories",
-    "prepare": "tsdx build",
+    "prepare": "npm run build",
     "size": "size-limit",
     "analyze": "size-limit --why",
     "storybook": "start-storybook -p 6006",
@@ -31,6 +31,7 @@
       "pre-commit": "npm run lint && npm run test"
     }
   },
+  "browserslist": ">0.25% or last 2 major versions and supports es6-module",
   "prettier": {
     "singleQuote": true,
     "trailingComma": "all"
@@ -61,6 +62,7 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "babel-loader": "^8.2.2",
+    "babel-plugin-polyfill-corejs3": "^0.1.0",
     "husky": "^4.3.8",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
@@ -70,5 +72,6 @@
     "tsdx": "^0.14.1",
     "tslib": "^2.1.0",
     "typescript": "^4.1.3"
-  }
+  },
+  "dependencies": {}
 }

--- a/src/marksomeParser.ts
+++ b/src/marksomeParser.ts
@@ -36,33 +36,42 @@ const EMPHASIZED_TEXT_REGEXP = /([*_])((?:\[.*?\][([].*?[)\]]|.)*?)\1/g;
 
 const REFERENCE_LINK_TEXT_REGEXP = /\[([^\]]*)\] ?\[([^\]]*)\]/g;
 
+function matchAll(
+  regexp: RegExp,
+  text: string,
+  onMatch: (match: RegExpExecArray) => void,
+) {
+  let match: RegExpExecArray | null;
+  while ((match = regexp.exec(text)) !== null) {
+    onMatch(match);
+  }
+}
+
 export function parseSegments(text: string): Segment[] {
   const matches: Match[] = [];
 
-  Array.from(text.matchAll(REFERENCE_LINK_TEXT_REGEXP)).forEach(
-    (referenceLinkRegExpMatch) => {
-      const innerText = referenceLinkRegExpMatch[1];
-      const reference = referenceLinkRegExpMatch[2];
-      const startIndex = referenceLinkRegExpMatch.index;
+  matchAll(REFERENCE_LINK_TEXT_REGEXP, text, (referenceLinkRegExpMatch) => {
+    const innerText = referenceLinkRegExpMatch[1];
+    const reference = referenceLinkRegExpMatch[2];
+    const startIndex = referenceLinkRegExpMatch.index;
 
-      if (!innerText || !reference || startIndex == null) {
-        return;
-      }
+    if (!innerText || !reference || startIndex == null) {
+      return;
+    }
 
-      const endIndex = startIndex + referenceLinkRegExpMatch[0].length;
+    const endIndex = startIndex + referenceLinkRegExpMatch[0].length;
 
-      matches.push({
-        type: 'reference-link',
-        innerText,
-        reference,
-        startIndex,
-        endIndex,
-        offset: 1,
-      });
-    },
-  );
+    matches.push({
+      type: 'reference-link',
+      innerText,
+      reference,
+      startIndex,
+      endIndex,
+      offset: 1,
+    });
+  });
 
-  Array.from(text.matchAll(STRONG_TEXT_REGEXP)).forEach((strongRegExpMatch) => {
+  matchAll(STRONG_TEXT_REGEXP, text, (strongRegExpMatch) => {
     const inlineMatch = getInlineMatchFromRegexpMatch(
       strongRegExpMatch,
       'strong',
@@ -73,18 +82,16 @@ export function parseSegments(text: string): Segment[] {
     }
   });
 
-  Array.from(text.matchAll(EMPHASIZED_TEXT_REGEXP)).forEach(
-    (emphasisRegExpMatch) => {
-      const inlineMatch = getInlineMatchFromRegexpMatch(
-        emphasisRegExpMatch,
-        'emphasis',
-      );
+  matchAll(EMPHASIZED_TEXT_REGEXP, text, (emphasisRegExpMatch) => {
+    const inlineMatch = getInlineMatchFromRegexpMatch(
+      emphasisRegExpMatch,
+      'emphasis',
+    );
 
-      if (inlineMatch) {
-        matches.push(inlineMatch);
-      }
-    },
-  );
+    if (inlineMatch) {
+      matches.push(inlineMatch);
+    }
+  });
 
   matches.sort((a, b) => a.startIndex - b.startIndex);
 


### PR DESCRIPTION
- define modern browserslist
- update `caniuse-lite` to latest
- install `babel-plugin-polyfill-corejs3`
- add polyfill checker around the `babel-plugin-polyfill-corejs3`
  - when running the build command, throw an error if any polyfill is required
- rework marksomeParser to stop depending on `String::matchAll`
- add **Supported browsers** section to README