### PR TITLE
Rework escaped marker detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-marksome",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-marksome",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.12.10",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "repository": "github:miguel-silva/react-marksome",
   "description": "Lightweight, flexible and readable labels in React using a subset of markdown",

--- a/test/marksomeParser.test.ts
+++ b/test/marksomeParser.test.ts
@@ -1323,7 +1323,7 @@ describe('reference links parsing (influenced by commonmark spec)', () => {
     ]);
   });
 
-  test('link labels cannot contain unescaped brackets', () => {
+  test('link labels cannot contain brackets', () => {
     expect(parseSegments('[foo][ref[bar]]')).toEqual([
       {
         type: 'reference-link',
@@ -1337,16 +1337,6 @@ describe('reference links parsing (influenced by commonmark spec)', () => {
         reference: 'bar',
       },
       ']',
-    ]);
-  });
-
-  test('link labels may contain escaped brackets', () => {
-    expect(parseSegments('[foo][ref\\[]')).toEqual([
-      {
-        type: 'reference-link',
-        content: ['foo'],
-        reference: 'ref\\[',
-      },
     ]);
   });
 


### PR DESCRIPTION
## Motivation

Currently, [Safari and iOS as a whole doesn't support lookbehind assertions regexp](https://caniuse.com/js-regexp-lookbehind).

## Changes

- remove all lookbehind regexp assertions (safari doesn't support them)
- start detecting escaped characters via js